### PR TITLE
Add GitHub Actions workflow for automatic IPA resigning

### DIFF
--- a/.github/workflows/resign.yml
+++ b/.github/workflows/resign.yml
@@ -1,0 +1,84 @@
+name: Resign IPA (Ad Hoc Multi-UDID)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ipa_path:
+        description: 'Path to IPA in repo (e.g., uploads/app.ipa)'
+        required: true
+        default: 'uploads/app.ipa'
+  push:
+    paths:
+      - 'uploads/*.ipa'
+      - 'tools/**'
+      - '.github/workflows/resign.yml'
+
+jobs:
+  resign:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Decode Provisioning Profile
+        run: |
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "${{ secrets.IOS_PROVISION_BASE64 }}" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/App.mobileprovision"
+
+      - name: Create Temporary Keychain & Import P12
+        run: |
+          KEYCHAIN=build.keychain
+          security create-keychain -p "" "$KEYCHAIN"
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "" "$KEYCHAIN"
+          echo "${{ secrets.IOS_P12_BASE64 }}" | base64 --decode > cert.p12
+          security import cert.p12 -k "$KEYCHAIN" -P "${{ secrets.IOS_P12_PASSWORD }}" -T /usr/bin/codesign
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN"
+
+      - name: Ensure Tools Executable
+        run: chmod +x tools/resign_ipa.sh
+
+      - name: Pick IPA path
+        id: pick
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            IPA="${{ github.event.inputs.ipa_path }}"
+          else
+            # fallback to first IPA under uploads
+            IPA="$(ls -1 uploads/*.ipa | head -n1)"
+          fi
+          echo "ipa=$IPA" >> $GITHUB_OUTPUT
+          echo "Using IPA: $IPA"
+
+      - name: Resign IPA
+        env:
+          SIGN_ID: ""
+        run: |
+          # حاول استكشاف اسم الشهادة تلقائياً
+          SIGN_ID="$(security find-identity -v -p codesigning | grep -oE 'iPhone Distribution:.*\)' | head -n1 || true)"
+          if [ -z "$SIGN_ID" ]; then
+            echo "Could not auto-detect signing identity. List identities:"
+            security find-identity -v -p codesigning
+            exit 1
+          fi
+          echo "Using signing identity: $SIGN_ID"
+
+          # نفّذ التوقيع: TEAMID/BUNDLEID ثابتة لك
+          ./tools/resign_ipa.sh \
+            "${{ steps.pick.outputs.ipa }}" \
+            "$HOME/Library/MobileDevice/Provisioning Profiles/App.mobileprovision" \
+            "$SIGN_ID" \
+            "66856YQ2FS" \
+            "com.xlop.myapp" \
+            "./tools/entitlements.plist"
+
+      - name: Upload Resigned IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: resigned-ipa
+          path: |
+            uploads/*-resigned.ipa
+            *-resigned.ipa
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# IPA & local stuff
+*.ipa
+*.p12
+*.mobileprovision
+*.b64
+cert.p12
+
+# macOS junk
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # signed
+
+Automatic IPA resigning via GitHub Actions.
+
+## Usage
+1. Place the unsigned IPA inside the `uploads/` directory.
+2. Add repository secrets:
+   - `IOS_P12_BASE64`: base64-encoded `.p12` certificate.
+   - `IOS_P12_PASSWORD`: password for the certificate.
+   - `IOS_PROVISION_BASE64`: base64-encoded provisioning profile containing device UDIDs.
+3. Trigger the **Resign IPA (Ad Hoc Multi-UDID)** workflow:
+   - Push an IPA to `uploads/`, or
+   - Run it manually from the Actions tab and specify the IPA path.
+
+The workflow signs the IPA with Team ID `66856YQ2FS`, bundle ID `com.xlop.myapp`,
+and production push entitlement, then uploads a `*-resigned.ipa` artifact.

--- a/tools/entitlements.plist
+++ b/tools/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>application-identifier</key>
+  <string>66856YQ2FS.com.xlop.myapp</string>
+  <key>keychain-access-groups</key>
+  <array>
+    <string>66856YQ2FS.*</string>
+  </array>
+  <key>aps-environment</key>
+  <string>production</string>
+</dict>
+</plist>

--- a/tools/resign_ipa.sh
+++ b/tools/resign_ipa.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -ne 6 ]; then
+  echo "Usage: $0 <ipa_path> <provision_path> <sign_identity> <team_id> <bundle_id> <entitlements_plist>" >&2
+  exit 1
+fi
+
+IPA_PATH="$1"
+PROVISION="$2"
+SIGN_ID="$3"
+TEAM_ID="$4"
+BUNDLE_ID="$5"
+ENTITLEMENTS="$6"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Unzipping IPA..."
+unzip -q "$IPA_PATH" -d "$WORKDIR"
+
+APP=$(find "$WORKDIR/Payload" -maxdepth 1 -name "*.app" -type d | head -n1)
+if [ -z "$APP" ]; then
+  echo "Could not find .app bundle in IPA" >&2
+  exit 1
+fi
+
+echo "Replacing provisioning profile..."
+cp "$PROVISION" "$APP/embedded.mobileprovision"
+
+echo "Updating Info.plist with bundle identifier..."
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :application-identifier $TEAM_ID.$BUNDLE_ID" "$APP/Info.plist" || true
+
+echo "Cleaning old signatures..."
+rm -rf "$APP/_CodeSignature"
+find "$APP" \( -name "*.framework" -o -name "*.dylib" \) | while IFS= read -r BUNDLE; do
+  rm -rf "$BUNDLE/_CodeSignature"
+done
+
+echo "Resigning frameworks and dylibs..."
+find "$APP" \( -name "*.framework" -o -name "*.dylib" \) | while IFS= read -r BUNDLE; do
+  codesign -fs "$SIGN_ID" --entitlements "$ENTITLEMENTS" "$BUNDLE"
+done
+
+echo "Resigning app..."
+codesign -fs "$SIGN_ID" --entitlements "$ENTITLEMENTS" "$APP"
+
+OUTPUT="${IPA_PATH%.ipa}-resigned.ipa"
+echo "Repacking IPA to $OUTPUT..."
+(
+  cd "$WORKDIR"
+  zip -qr "$OUTPUT" Payload
+)
+mv "$WORKDIR/$OUTPUT" "$(dirname "$IPA_PATH")/"
+
+echo "Done: $(dirname "$IPA_PATH")/${OUTPUT}"


### PR DESCRIPTION
## Summary
- add macOS workflow to resign IPAs with specified team and bundle IDs
- include entitlements and resign script used by the workflow
- document how to use the resigning pipeline

## Testing
- `bash -n tools/resign_ipa.sh`
- `shellcheck tools/resign_ipa.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5fda4c1288324b6b85e70fee980b9